### PR TITLE
fix:view:performances:index:passed events are labelled with words 

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -46,8 +46,7 @@ module EventsHelper
   end
 
   def passed_label(events)
-    return '--->' if events.empty?
-
+    events = [nil] if events.empty?
     I18n.t("#{get_dictionnary(events.first)}.passed_events_title").html_safe
   end
 


### PR DESCRIPTION
and…not with arrows